### PR TITLE
Add pexip-fix-socket-already-connected-handling.patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+curl (7.88.1-10+deb12u6+pexip24u2) pexip; urgency=medium
+
+  * Add pexip-fix-socket-already-connected-handling.patch
+
+ -- Knut Saastad <knut.saastad@pexip.com>  Thu, 18 Jul 2024 11:33:00 +0000
+
 curl (7.88.1-10+deb12u6+pexip24u1) pexip; urgency=medium
 
   * New upstream release

--- a/debian/patches/pexip-fix-socket-already-connected-handling.patch
+++ b/debian/patches/pexip-fix-socket-already-connected-handling.patch
@@ -1,0 +1,23 @@
+Description: Patch cf-socket to honor CURL_SOCKOPT_ALREADY_CONNECTED returned from the CURLOPT_SOCKOPTFUNCTION callback during socket setup. [https://github.com/bch/curl/commit/603c4c526c3c7267ba483278173e1dbb20a52baa]
+Origin: Pexip
+Forwarded: not-needed
+Author: Knut Saastad <knut.saastad@pexip.com>
+Last-Update: 2024-07-17
+
+Index: curl/lib/cf-socket.c
+===================================================================
+--- curl.orig/lib/cf-socket.c
++++ curl/lib/cf-socket.c
+@@ -1084,6 +1084,11 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
+     if(result)
+       goto out;
+ 
++    if(cf->connected) {
++      *done = TRUE;
++      return CURLE_OK;
++    }
++
+     /* Connect TCP socket */
+     rc = do_connect(cf, data, cf->conn->bits.tcp_fastopen);
+     if(-1 == rc) {
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -48,3 +48,6 @@ CVE-2024-2398.patch
 # Used to generate packages for the other crypto libraries.
 90_gnutls.patch
 99_nss.patch
+
+# Pexip patches
+pexip-fix-socket-already-connected-handling.patch


### PR DESCRIPTION
I wan't completely sure about the versioning scheme in the changelog, so just upped it from 7.88.1-10+deb12u6+pexip24u1 to 7.88.1-10+deb12u6+pexip24u2. Please let me know if this is incorrect. 